### PR TITLE
Fix List and Dict types

### DIFF
--- a/kickbase_api/kickbase.py
+++ b/kickbase_api/kickbase.py
@@ -23,6 +23,7 @@ from kickbase_api.models.player import Player
 from kickbase_api.models.response.league_stats_response import LeagueStatsResponse
 from kickbase_api.models.user import User
 
+from typing import List, Tuple
 
 class Kickbase:
     base_url: str = None
@@ -41,7 +42,7 @@ class Kickbase:
         self.firestore_project = firestore_project
         self.google_identity_toolkit_api_key = google_identity_toolkit_api_key
 
-    def login(self, username: str, password: str) -> (User, [LeagueData]):
+    def login(self, username: str, password: str) -> Tuple(User, List[LeagueData]):
         data = {
             "email": username,
             "password": password,
@@ -77,7 +78,7 @@ class Kickbase:
             return False
         return self.firebase_token_expire > datetime.now(timezone.utc) - timedelta(minutes=5)
 
-    def leagues(self) -> [LeagueData]:
+    def leagues(self) -> List[LeagueData]:
         r = self._do_get("/leagues/", True)
 
         if r.status_code == 200:
@@ -116,7 +117,7 @@ class Kickbase:
         else:
             raise KickbaseException()
 
-    def league_users(self, league: Union[str, LeagueData]) -> [LeagueUserData]:
+    def league_users(self, league: Union[str, LeagueData]) -> List[LeagueUserData]:
         league_id = self._get_league_id(league)
 
         r = self._do_get("/leagues/{}/users".format(league_id), True)
@@ -148,7 +149,7 @@ class Kickbase:
         else:
             raise KickbaseException()
 
-    def league_feed(self, start_index: int, league: Union[str, LeagueData]) -> [FeedItem]:
+    def league_feed(self, start_index: int, league: Union[str, LeagueData]) -> List[FeedItem]:
         league_id = self._get_league_id(league)
 
         r = self._do_get("/leagues/{}/feed?start={}".format(league_id, start_index), True)
@@ -172,8 +173,7 @@ class Kickbase:
         else:
             raise KickbaseException()
 
-    def league_feed_comments(self, league: Union[str, LeagueData], feed_item: Union[str, FeedItem]) -> [
-        FeedItemComment]:
+    def league_feed_comments(self, league: Union[str, LeagueData], feed_item: Union[str, FeedItem]) -> List[FeedItemComment]:
         league_id = self._get_league_id(league)
         feed_item_id = self._get_feed_item_id(feed_item)
 
@@ -199,8 +199,7 @@ class Kickbase:
         else:
             raise KickbaseException()
 
-    def league_user_players(self, league: Union[str, LeagueData], user: Union[str, User], match_day: int = 0) -> [
-        Player]:
+    def league_user_players(self, league: Union[str, LeagueData], user: Union[str, User], match_day: int = 0) -> List[Player]:
         league_id = self._get_league_id(league)
         user_id = self._get_user_id(user)
 
@@ -233,7 +232,7 @@ class Kickbase:
         else:
             raise KickbaseException()
 
-    def search_player(self, search_query: str) -> [Player]:
+    def search_player(self, search_query: str) -> List[Player]:
         r = self._do_get("/competition/search?t={}".format(search_query))
 
         if r.status_code == 200:
@@ -241,7 +240,7 @@ class Kickbase:
         else:
             raise KickbaseException()
 
-    def team_players(self, team_id: str) -> [Player]:
+    def team_players(self, team_id: str) -> List[Player]:
         r = self._do_get("/competition/teams/{}/players".format(team_id))
 
         if r.status_code == 200:
@@ -249,7 +248,7 @@ class Kickbase:
         else:
             raise KickbaseException()
 
-    def top_25_players(self) -> [Player]:
+    def top_25_players(self) -> List[Player]:
         r = self._do_get("/competition/best?position=0")
 
         if r.status_code == 200:
@@ -423,7 +422,7 @@ class Kickbase:
         token = self.chat_token()
         self.exchange_custom_token(token)
 
-    def chat_messages(self, league: Union[str, LeagueData], page_size: int = 30, next_page_token: str = None) -> ([ChatItem], str):
+    def chat_messages(self, league: Union[str, LeagueData], page_size: int = 30, next_page_token: str = None) -> Tuple(List[ChatItem], str):
         if self.google_identity_toolkit_api_key is None:
             return []
         

--- a/kickbase_api/models/chat_item.py
+++ b/kickbase_api/models/chat_item.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from kickbase_api.models._transforms import parse_date
 
+from typing import List
 
 class ChatItem:
     id: str = None
@@ -10,7 +11,7 @@ class ChatItem:
     date: datetime = None
     user_id: str = None
     username: str = None
-    seen_by: [str] = []
+    seen_by: List[str] = []
 
     def __init__(self, d: dict = {}):
         if "name" in d:

--- a/kickbase_api/models/league_user_data.py
+++ b/kickbase_api/models/league_user_data.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from kickbase_api.models._transforms import parse_date
 from kickbase_api.models.base_model import BaseModel
 
+from typing import List
 
 class LeagueUserData(BaseModel):
     id: str = None
@@ -11,7 +12,7 @@ class LeagueUserData(BaseModel):
     profile_image_path: str = None
     cover_image_path: str = None
     status: int = None
-    perms: [int] = None
+    perms: List[int] = None
     
     def __init__(self, d: dict = {}):
         self._json_transform = {

--- a/kickbase_api/models/league_user_profile.py
+++ b/kickbase_api/models/league_user_profile.py
@@ -4,10 +4,11 @@ from kickbase_api.models._transforms import parse_date, parse_key_value_array_to
 from kickbase_api.models.base_model import BaseModel
 from kickbase_api.models.league_user_profile_season_stats import LeagueUserProfileSeasonStats
 
+from typing import List, Dict
 
 class LeagueUserProfile(BaseModel):
     flags: int = None
-    perms: [int] = None
+    perms: List[int] = None
     level_achieved: int = None
     current_season_id: int = None
     placement: int = None
@@ -22,8 +23,8 @@ class LeagueUserProfile(BaseModel):
     sold: int = None
     highest_team_value: float = None
     
-    seasons: [LeagueUserProfileSeasonStats] = None
-    team_values: {datetime: float}
+    seasons: List[LeagueUserProfileSeasonStats] = None
+    team_values: Dict[datetime, float]
     
     def __init__(self, d: dict = {}):
         self._json_transform = {

--- a/kickbase_api/models/league_user_profile_season_stats.py
+++ b/kickbase_api/models/league_user_profile_season_stats.py
@@ -4,6 +4,7 @@ from kickbase_api.models._transforms import parse_date, parse_key_value_array_to
 from kickbase_api.models.base_model import BaseModel
 from kickbase_api.models.league_match_day_user_stats import LeagueMatchDayUserStats
 
+from typing import List
 
 class LeagueUserProfileSeasonStats(BaseModel):
     season_id: str = None
@@ -14,7 +15,7 @@ class LeagueUserProfileSeasonStats(BaseModel):
     max_points: int = None    
     wins: int = None
     
-    match_days: [LeagueMatchDayUserStats] = None
+    match_days: List[LeagueMatchDayUserStats] = None
    
     def __init__(self, d: dict = {}):
         self._json_transform = {

--- a/kickbase_api/models/league_user_stats.py
+++ b/kickbase_api/models/league_user_stats.py
@@ -4,6 +4,7 @@ from kickbase_api.models._transforms import parse_date, parse_key_value_array_to
 from kickbase_api.models.base_model import BaseModel
 from kickbase_api.models.league_user_season_stats import LeagueUserSeasonStats
 
+from typing import List, Dict
 
 class LeagueUserStats(BaseModel):
     name: str = None
@@ -14,8 +15,8 @@ class LeagueUserStats(BaseModel):
     points: int = None
     team_value: float = None
     
-    seasons: [LeagueUserSeasonStats] = None
-    team_values: {datetime: float}
+    seasons: List[LeagueUserSeasonStats] = None
+    team_values: Dict[datetime, float]
     
     def __init__(self, d: dict = {}):
         self._json_transform = {

--- a/kickbase_api/models/lineup.py
+++ b/kickbase_api/models/lineup.py
@@ -1,9 +1,11 @@
 from kickbase_api.models.base_model import BaseModel
 
+from typing import List
+
 
 class LineUp(BaseModel):
     type: str = None
-    players: [str] = None
+    players: List[str] = None
 
     def __init__(self, d: dict = {}):
         self._json_transform = {

--- a/kickbase_api/models/market.py
+++ b/kickbase_api/models/market.py
@@ -1,10 +1,12 @@
 from kickbase_api.models.base_model import BaseModel
 from kickbase_api.models.market_player import MarketPlayer
 
+from typing import List
+
 
 class Market(BaseModel):
     closed: bool = None
-    players: [MarketPlayer] = None
+    players: List[MarketPlayer] = None
     
     def __init__(self, d: dict = {}):
         self._json_transform = {

--- a/kickbase_api/models/market_player.py
+++ b/kickbase_api/models/market_player.py
@@ -5,6 +5,8 @@ from kickbase_api.models.base_model import BaseModel
 from kickbase_api.models.market_player_offer import MarketPlayerOffer
 from kickbase_api.models.player import _map_player_position, _map_player_status, PlayerPosition, PlayerStatus
 
+from typing import List
+
 
 class MarketPlayer(BaseModel):
     id: str = None
@@ -32,7 +34,7 @@ class MarketPlayer(BaseModel):
     expiry: int = None
     lus: int = None
     
-    offers: [MarketPlayerOffer] = None
+    offers: List[MarketPlayerOffer] = None
     
     def __init__(self, d: dict = {}):
         self._json_transform = {

--- a/kickbase_api/models/response/league_stats_response.py
+++ b/kickbase_api/models/response/league_stats_response.py
@@ -1,10 +1,11 @@
 from kickbase_api.models.league_match_day_stats_data import LeagueMatchDayStatsData
 
+from typing import List, Dict
 
 class LeagueStatsResponse:
     
     current_day: int = None
-    match_days: {int: [LeagueMatchDayStatsData]} = {}
+    match_days: Dict[int, List[LeagueMatchDayStatsData]] = {}
 
     def __init__(self, d: dict):
         self.current_day = d["currentDay"]


### PR DESCRIPTION
Types for dicts and lists where declared similar to Typescript syntax. e.g. [str] -> List[str], {str: float} -> Dict[str, float]